### PR TITLE
Allow class names with - in them

### DIFF
--- a/snabbdom-jsx.js
+++ b/snabbdom-jsx.js
@@ -23,7 +23,7 @@ function normalizeAttrs(attrs, nsURI, defNS, modules) {
   for(var key in attrs) {
     const parts = key.split('-');
     if(parts.length > 1)
-      addAttr(parts[0], parts[1], attrs[key]);
+      addAttr(parts[0], key.slice(key.indexOf('-')+1), attrs[key]);
     else if(!map[key])
       addAttr(defNS, parts[0], attrs[key]);
   }


### PR DESCRIPTION
Before, using class-has-error={...} would add or remove the class "has-", instead of "has-error" like it should.