### PR TITLE
flatten child arrays to allow nesting

### DIFF
--- a/snabbdom-jsx.js
+++ b/snabbdom-jsx.js
@@ -85,9 +85,8 @@ function flatten(nested, start, flat) {
 }
 
 function maybeFlatten(array) {
-  console.log("mmmaybe")
   if (array) {
-    for (var i = 0, len=array.length; i < len; i++) {
+    for (var i = 0, len = array.length; i < len; i++) {
       if (Array.isArray(array[i])) {
         var flat = array.slice(0, i);
         flatten(array, i, flat);

--- a/snabbdom-jsx.js
+++ b/snabbdom-jsx.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var SVGNS = 'http://www.w3.org/2000/svg';    
+var SVGNS = 'http://www.w3.org/2000/svg';
 var modulesNS = ['hook', 'on', 'style', 'class', 'props', 'attrs'];
 var slice = Array.prototype.slice;
 
@@ -73,8 +73,35 @@ function buildFromComponent(nsURI, defNS, modules, tag, attrs, children) {
   return res;
 }
 
+function flatten(nested, start, flat) {
+  for (var i = start, len = nested.length; i < len; i++) {
+    var item = nested[i];
+    if (Array.isArray(item)) {
+      flatten(item, 0, flat);
+    } else {
+      flat.push(item);
+    }
+  }
+}
+
+function maybeFlatten(array) {
+  console.log("mmmaybe")
+  if (array) {
+    for (var i = 0, len=array.length; i < len; i++) {
+      if (Array.isArray(array[i])) {
+        var flat = array.slice(0, i);
+        flatten(array, i, flat);
+        array = flat;
+        break;
+      }
+    }
+  }
+  return array;
+}
+
 function buildVnode(nsURI, defNS, modules, tag, attrs, children) {
   attrs = attrs || {};
+  children = maybeFlatten(children);
   if(typeof tag === 'string') {
     return buildFromStringTag(nsURI, defNS, modules, tag, attrs, children)
   } else {


### PR DESCRIPTION
It seems that snabbdom does not allow nested arrays within the children array. This means you can't write code like, e.g:

```js
const todos = [{title: "buy some bread"}, ...];
const renderTodo = ({title}) => <li>{title}</li>;
const todosList = (
  <ul>
    <li>sticky todo</li>
    { todos.map(renderTodo) }
  </ul>
);
```

because this essentially translates to

```js
h('ul', [h('li', 'sticky todo'), [h('li', 'buy some bread')]]);
```

Note that the second item of the ul's children array is itself an array. Snabbdom doesn't like this and fails silently, rendering the string 'undefined' in place of the array.

Also note that 

```js
const todosList = (
  <ul>
    { todos.map(renderTodo) }
  </ul>
);
```

works perfectly well because if there is only one child and it is an array, snabbdom-jsx uses it as the children array.

Perhaps this is the intended behaviour. My use case is probably somewhat rare and maybe it's fine to fall back to `h` to handle such cases. Anyway I figured I'd offer this as a PR because it's not much code and shouldn't touch perf outside of extreme cases.